### PR TITLE
Fix Portability

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
-mkdir m4
 autoreconf -fiv || exit 1;
 echo "Now type './configure' to configure riofs project"

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,8 @@ AC_DEFINE(VERSION_MICRO, version_micro, [RioFS micro version])
 
 AC_CONFIG_HEADERS([include/config.h])
 
+AC_USE_SYSTEM_EXTENSIONS
+
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_INSTALL
@@ -140,6 +142,8 @@ AC_SUBST(MAGIC_LIBS)
 if test "x$libmagic" = "xtrue" ; then
     AC_DEFINE(MAGIC_ENABLED, [1], [Define to use libmagic])
 fi
+
+AX_EXECINFO()
 
 # check if we need to build test applications
 AC_MSG_CHECKING([if building example applications])

--- a/include/global.h
+++ b/include/global.h
@@ -18,36 +18,12 @@
 #ifndef _GLOBAL_H_
 #define _GLOBAL_H_
 
-#ifndef _XOPEN_SOURCE
-#define _XOPEN_SOURCE 500
-#endif
-
-#ifndef _BSD_SOURCE
-#define _BSD_SOURCE
-#endif
-
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-
-#ifndef _DEFAULT_SOURCE
-#define _DEFAULT_SOURCE
-#endif
-
-#ifndef _DARWIN_C_SOURCE
-#define _DARWIN_C_SOURCE
-#endif
-
 #include "config.h"
 
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
 #include <stdio.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <netinet/ip.h>
-#include <arpa/inet.h>
 #include <ctype.h>
 #if defined(__APPLE__)
     #include <machine/endian.h>
@@ -58,6 +34,9 @@
 #endif
 #if defined(__GLIBC__)
     #include <gnu/libc-version.h>
+#endif
+
+#if defined(HAVE_BACKTRACE)
     #include <execinfo.h>
 #endif
 
@@ -67,7 +46,6 @@
 
 #include <signal.h>
 #include <sys/queue.h>
-#include <ctype.h>
 #include <sys/types.h>
 #include <pwd.h>
 #include <sys/resource.h>
@@ -77,6 +55,10 @@
     #include <sys/prctl.h>
 #endif
 
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <arpa/inet.h>
 #include <netinet/tcp.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/include/global.h
+++ b/include/global.h
@@ -55,10 +55,12 @@
     #include <sys/endian.h>
 #else
     #include <endian.h>
+#endif
+#if defined(__GLIBC__)
     #include <gnu/libc-version.h>
+    #include <execinfo.h>
 #endif
 
-#include <execinfo.h>
 #if defined(__APPLE__) || defined(__FreeBSD__)
     #include <ucontext.h>
 #endif
@@ -93,6 +95,7 @@
 #include <openssl/evp.h>
 #include <openssl/ssl.h>
 #include <openssl/md5.h>
+#include <openssl/rand.h>
 
 #include <event2/event.h>
 #include <event2/listener.h>

--- a/m4/ax_execinfo.m4
+++ b/m4/ax_execinfo.m4
@@ -1,0 +1,67 @@
+# ===========================================================================
+#        http://www.gnu.org/software/autoconf-archive/ax_execinfo.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_EXECINFO([ACTION-IF-EXECINFO-H-IS-FOUND], [ACTION-IF-EXECINFO-H-IS-NOT-FOUND], [ADDITIONAL-TYPES-LIST])
+#
+# DESCRIPTION
+#
+#   Checks for execinfo.h header and if the len parameter/return type can be
+#   found from a list, also define backtrace_size_t to that type.
+#
+#   By default the list of types to try contains int and size_t, but should
+#   some yet undiscovered system use e.g. unsigned, the 3rd argument can be
+#   used for extensions. I'd like to hear of further suggestions.
+#
+#   Executes ACTION-IF-EXECINFO-H-IS-FOUND when present and the execinfo.h
+#   header is found or ACTION-IF-EXECINFO-H-IS-NOT-FOUND in case the header
+#   seems unavailable.
+#
+#   Also adds -lexecinfo to LIBS on BSD if needed.
+#
+# LICENSE
+#
+#   Copyright (c) 2014 Thomas Jahns <jahns@dkrz.de>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 1
+
+AC_DEFUN([AX_EXECINFO],
+  [AC_CHECK_HEADERS([execinfo.h])
+   AS_IF([test x"$ac_cv_header_execinfo_h" = xyes],
+     [AC_CACHE_CHECK([size parameter type for backtrace()],
+	[ax_cv_proto_backtrace_type],
+	[AC_LANG_PUSH([C])
+	 for ax_cv_proto_backtrace_type in size_t int m4_ifnblank([$3],[$3 ])none; do
+	   AS_IF([test "${ax_cv_proto_backtrace_type}" = none],
+	     [ax_cv_proto_backtrace_type= ; break])
+	   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+#include <execinfo.h>
+extern
+${ax_cv_proto_backtrace_type} backtrace(void **addrlist, ${ax_cv_proto_backtrace_type} len);
+char **backtrace_symbols(void *const *buffer, ${ax_cv_proto_backtrace_type} size);
+])],
+	   [break])
+	 done
+	 AC_LANG_POP([C])])])
+   AS_IF([test x${ax_cv_proto_backtrace_type} != x],
+     [AC_DEFINE_UNQUOTED([backtrace_size_t], [$ax_cv_proto_backtrace_type],
+        [Defined to return type of backtrace().])])
+   AC_SEARCH_LIBS([backtrace],[execinfo])
+   AS_IF([test x"${ax_cv_proto_backtrace_type}" != x -a x"$ac_cv_header_execinfo_h" = xyes -a x"$ac_cv_search_backtrace" != xno],
+     [AC_DEFINE([HAVE_BACKTRACE],[1],
+        [Defined if backtrace() could be fully identified.])
+     ]m4_ifnblank([$1],[$1
+]),m4_ifnblank([$2],[$2
+]))])
+dnl
+dnl Local Variables:
+dnl mode: autoconf
+dnl End:
+dnl

--- a/src/main.c
+++ b/src/main.c
@@ -243,7 +243,7 @@ static void sigsegv_cb (int sig_num, siginfo_t *info, void * ucontext)
 
     fprintf (f, "signal %d (%s), address is %p from %p\n", sig_num, strsignal (sig_num), info->si_addr, (void *)caller_address);
 
-#if defined(__GLIBC__)
+#if defined(__GLIBC__) || defined(__APPLE__)
     size = backtrace (array, 50);
 
     /* overwrite sigaction with caller's address */

--- a/src/main.c
+++ b/src/main.c
@@ -243,6 +243,7 @@ static void sigsegv_cb (int sig_num, siginfo_t *info, void * ucontext)
 
     fprintf (f, "signal %d (%s), address is %p from %p\n", sig_num, strsignal (sig_num), info->si_addr, (void *)caller_address);
 
+#if defined(__GLIBC__)
     size = backtrace (array, 50);
 
     /* overwrite sigaction with caller's address */
@@ -255,9 +256,10 @@ static void sigsegv_cb (int sig_num, siginfo_t *info, void * ucontext)
         fprintf (f, "[bt]: (%d) %s\n", i, messages[i]);
     }
 
-    fflush (f);
-
     free (messages);
+#endif // __GLIBC__
+
+    fflush (f);
 
     LOG_err (APP_LOG, "signal %d (%s), address is %p from %p\n", sig_num, strsignal (sig_num), info->si_addr, (void *)caller_address);
 #endif // __FreeBSD__
@@ -675,10 +677,6 @@ int main (int argc, char *argv[])
     SSL_load_error_strings ();
     SSL_library_init ();
 #endif
-    if (!RAND_poll ()) {
-        fprintf(stderr, "RAND_poll() failed.\n");
-        return -1;
-    }
     g_random_set_seed (time (NULL));
 
     // init main app structure
@@ -734,7 +732,7 @@ int main (int argc, char *argv[])
                 LIBEVENT_VERSION,
                 FUSE_MAJOR_VERSION, FUSE_MINOR_VERSION
         );
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || !defined(__GLIBC__)
         g_fprintf (stdout, "\n");
 #else
         g_fprintf (stdout, "  glibc: %s\n", gnu_get_libc_version ());

--- a/src/utils.c
+++ b/src/utils.c
@@ -30,7 +30,7 @@ gchar *get_random_string (size_t len, gboolean readable)
         for (i = 0; i < len; i++)
             out[i] = readable_chars[rand() % strlen (readable_chars)];
     } else {
-        if (!RAND_pseudo_bytes ((unsigned char *)out, len))
+        if (!RAND_bytes ((unsigned char *)out, len))
             return out;
     }
 

--- a/tests/client_pool_test.c
+++ b/tests/client_pool_test.c
@@ -66,7 +66,7 @@ static GList *populate_file_list (gint max_files, GList *l_files, gchar *in_dir)
         fdata->checked = FALSE;
         bytes_len = g_random_int_range (100000, 1000000);
         bytes = g_malloc (bytes_len + 1);
-        RAND_pseudo_bytes ((unsigned char *)bytes, bytes_len);
+        RAND_bytes ((unsigned char *)bytes, bytes_len);
         *(bytes + bytes_len) = '\0';
 
         name = get_random_string (15, TRUE);


### PR DESCRIPTION
This pull request fixes the portability on musl and on alternative OpenSSL implementations

LibreSSL removed deprecated functions from the headers. OpenSSL team implement a "strict" mode which does the same, but is optional. I only tested against LibreSSL, but it should work with BoringSSL.

My first commit also removes RAND_poll which is called automatically which I failed to mention in the commit message. RAND_pseudo_bytes is deprecated shouldn't be used anymore.

I may test OpenBSD, but their fuse implementation may need some special workarounds.