### PR TITLE
ETag cache validation patches

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -156,6 +156,16 @@ AC_MSG_RESULT([$enable_test_apps])
 
 AC_DEFINE(FUSE_USE_VERSION, 26, [Fuse API Version])
 
+# check if we should enable strict compile warnings
+AC_ARG_ENABLE(strict-compile,
+     AS_HELP_STRING(--enable-strict-compile, enable support for strict compiler warnings),
+     [], [enable_strict_compile=no]
+)
+
+if test "x$enable_strict_compile" = "xyes" ; then
+    CFLAGS="$CFLAGS -Wextra -pedantic -Wall"
+fi
+
 # check if we should enable verbose debugging
 AC_ARG_ENABLE(debug,
      AS_HELP_STRING(--enable-debug, enable support for running in debug mode),

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 m4_define([version_major], [0])
-m4_define([version_minor], [7])
+m4_define([version_minor], [8])
 m4_define([version_micro], [0])
 m4_define([version_micro_extra], version_micro)
 m4_append([version_micro_extra], [])

--- a/include/cache_mng.h
+++ b/include/cache_mng.h
@@ -44,10 +44,6 @@ guint64 cache_mng_size (CacheMng *cmng);
 // return total size of cached file
 guint64 cache_mng_get_file_length (CacheMng *cmng, fuse_ino_t ino);
 
-// return MD5 of cached file.
-// if result is TRUE then md5str will containd string with MD5 sum
-gboolean cache_mng_get_md5 (CacheMng *cmng, fuse_ino_t ino, gchar **md5str);
-
 // return version ID of cached file
 // return NULL if version ID is not set
 const gchar *cache_mng_get_version_id (CacheMng *cmng, fuse_ino_t ino);

--- a/include/cache_mng.h
+++ b/include/cache_mng.h
@@ -53,5 +53,9 @@ gboolean cache_mng_get_md5 (CacheMng *cmng, fuse_ino_t ino, gchar **md5str);
 const gchar *cache_mng_get_version_id (CacheMng *cmng, fuse_ino_t ino);
 void cache_mng_update_version_id (CacheMng *cmng, fuse_ino_t ino, const gchar *version_id);
 
+// return and update local copy of AWS ETag for this file
+const char *cache_mng_get_etag(CacheMng *cmng, fuse_ino_t ino);
+gboolean cache_mng_update_etag(CacheMng *cmng, fuse_ino_t ino, const char *etag);
+
 void cache_mng_get_stats (CacheMng *cmng, guint32 *entries_num, guint64 *total_size, guint64 *cache_hits, guint64 *cache_miss);
 #endif

--- a/include/cache_mng.h
+++ b/include/cache_mng.h
@@ -44,11 +44,6 @@ guint64 cache_mng_size (CacheMng *cmng);
 // return total size of cached file
 guint64 cache_mng_get_file_length (CacheMng *cmng, fuse_ino_t ino);
 
-// return version ID of cached file
-// return NULL if version ID is not set
-const gchar *cache_mng_get_version_id (CacheMng *cmng, fuse_ino_t ino);
-void cache_mng_update_version_id (CacheMng *cmng, fuse_ino_t ino, const gchar *version_id);
-
 // return and update local copy of AWS ETag for this file
 const char *cache_mng_get_etag(CacheMng *cmng, fuse_ino_t ino);
 gboolean cache_mng_update_etag(CacheMng *cmng, fuse_ino_t ino, const char *etag);

--- a/include/conf_keys.h
+++ b/include/conf_keys.h
@@ -43,7 +43,6 @@ const gchar *conf_keys_str[] = {
     "filesystem.md5_enabled",
     "filesystem.cache_enabled",
     "filesystem.cache_dir",
-    "filesystem.cache_dir_max_size",
     "filesystem.cache_object_ttl",
     "filesystem.uid",
     "filesystem.gid",

--- a/include/conf_keys.h
+++ b/include/conf_keys.h
@@ -40,7 +40,6 @@ const gchar *conf_keys_str[] = {
     "connection.max_retries",
     "filesystem.dir_cache_max_time",
     "filesystem.file_cache_max_time",
-    "filesystem.md5_enabled",
     "filesystem.cache_enabled",
     "filesystem.cache_dir",
     "filesystem.cache_object_ttl",

--- a/include/dir_tree.h
+++ b/include/dir_tree.h
@@ -33,8 +33,6 @@ void dir_tree_destroy (DirTree *dtree);
 DirEntry *dir_tree_update_entry (DirTree *dtree, const gchar *path, DirEntryType type,
     fuse_ino_t parent_ino, const gchar *entry_name, long long size, time_t last_modified);
 
-void dir_tree_entry_update_xattrs (DirEntry *en, struct evkeyvalq *headers);
-
 // mark that DirTree is being updated
 
 void dir_tree_start_update (DirEntry *en, G_GNUC_UNUSED const gchar *dir_path);

--- a/include/global.h
+++ b/include/global.h
@@ -61,6 +61,7 @@
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
 #include <sys/stat.h>
+#include <inttypes.h>
 #include <fcntl.h>
 #include <math.h>
 #include <ftw.h>

--- a/include/http_connection.h
+++ b/include/http_connection.h
@@ -81,14 +81,14 @@ typedef void (*HttpConnection_on_entry_sent_cb) (gpointer ctx, gboolean success)
 void http_connection_file_send (HttpConnection *con, int fd, const gchar *resource_path,
     HttpConnection_on_entry_sent_cb on_entry_sent_cb, gpointer ctx);
 
-typedef void (*HttpConnection_responce_cb) (HttpConnection *con, gpointer ctx, gboolean success,
+typedef void (*HttpConnection_response_cb) (HttpConnection *con, gpointer ctx, gboolean success,
         const gchar *buf, size_t buf_len, struct evkeyvalq *headers);
 gboolean http_connection_make_request (HttpConnection *con,
     const gchar *resource_path,
     const gchar *http_cmd,
     struct evbuffer *out_buffer,
     gboolean enable_retry, gpointer parent_request_data,
-    HttpConnection_responce_cb responce_cb,
+    HttpConnection_response_cb response_cb,
     gpointer ctx);
 
 #endif

--- a/include/log.h
+++ b/include/log.h
@@ -35,6 +35,9 @@ void logger_set_color (gboolean use);
 void logger_set_file (FILE *f);
 void logger_destroy (void);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvariadic-macros"
+
 #define LOG_debug(subsystem, x...) \
 G_STMT_START { \
     logger_log_msg (__FILE__, __LINE__, __func__, LOG_debug, subsystem, x); \
@@ -49,5 +52,7 @@ G_STMT_START { \
 G_STMT_START { \
     logger_log_msg (__FILE__, __LINE__, __func__, LOG_err, subsystem, x); \
 } G_STMT_END
+
+#pragma GCC diagnostic pop
 
 #endif

--- a/riofs.conf.xml
+++ b/riofs.conf.xml
@@ -80,9 +80,6 @@
     <!-- time to keep file attributes cache (seconds) -->
     <file_cache_max_time type="uint">10</file_cache_max_time>
 
-    <!-- set True to enable calculating MD5 sum of file content, increases CPU load -->
-    <md5_enabled type="boolean">True</md5_enabled>
-    
     <!-- set True to enable objects caching -->
     <cache_enabled type="boolean">True</cache_enabled>
 

--- a/riofs.conf.xml
+++ b/riofs.conf.xml
@@ -89,8 +89,12 @@
     <!-- directory for storing cache objects -->
     <cache_dir type="string">/tmp/riofs</cache_dir>
 
-    <!-- maximum size of cache directory (1Gb) -->
+    <!-- If cache_dir_max_megabyte_size is set, it applies, -->
+    <!-- ... otherwise cache_dir_max_size applies and must be set. -- >
+    <!-- maximum size of cache directory (1Gb default, in byte units, 4 GByte max) -->
     <cache_dir_max_size type="uint">1073741824</cache_dir_max_size>
+    <!-- maximum size of cache directory (1Gb default, in MByte units, 4 PetaByte max) -->
+    <!-- <cache_dir_max_megabyte_size type="uint">1024</cache_dir_max_megabyte_size> -->
 
     <!-- maximum time of cached object, 10 min -->
     <cache_object_ttl type="uint">600</cache_object_ttl>

--- a/src/cache_mng.c
+++ b/src/cache_mng.c
@@ -74,7 +74,14 @@ CacheMng *cache_mng_create (Application *app)
     cmng->q_lru = g_queue_new ();
     cmng->size = 0;
     cmng->check_time = time (NULL);
-    cmng->max_size = conf_get_uint (application_get_conf (cmng->app), "filesystem.cache_dir_max_size");
+    // If "filesystem.cache_dir_max_megabyte_size" is set, use it, else use "filesystem.cache_dir_max_size"
+    if (conf_node_exists (application_get_conf (cmng->app), "filesystem.cache_dir_max_megabyte_size")) {
+        cmng->max_size = conf_get_uint (application_get_conf (cmng->app), "filesystem.cache_dir_max_megabyte_size");
+        cmng->max_size *= 1024 * 1024;      // Convert from megabytes to bytes
+    } else {
+        cmng->max_size = conf_get_uint (application_get_conf (cmng->app), "filesystem.cache_dir_max_size");
+    }
+    LOG_debug (CMNG_LOG, "Maximum cache size (bytes): %llu", cmng->max_size);
     // generate random folder name for storing cache
     rnd_str = get_random_string (20, TRUE);
     cmng->cache_dir = g_strdup_printf ("%s/%s",

--- a/src/cache_mng.c
+++ b/src/cache_mng.c
@@ -81,7 +81,7 @@ CacheMng *cache_mng_create (Application *app)
     } else {
         cmng->max_size = conf_get_uint (application_get_conf (cmng->app), "filesystem.cache_dir_max_size");
     }
-    LOG_debug (CMNG_LOG, "Maximum cache size (bytes): %llu", cmng->max_size);
+    LOG_debug (CMNG_LOG, "Maximum cache size (bytes): %"PRId64, cmng->max_size);
     // generate random folder name for storing cache
     rnd_str = get_random_string (20, TRUE);
     cmng->cache_dir = g_strdup_printf ("%s/%s",

--- a/src/cache_mng.c
+++ b/src/cache_mng.c
@@ -190,52 +190,6 @@ static void cache_mng_rm_cache_dir (CacheMng *cmng)
     }
 }
 
-
-// we can only get md5 of an object containing 1 range
-// XXX: move code to separate thread
-gboolean cache_mng_get_md5 (CacheMng *cmng, fuse_ino_t ino, gchar **md5str)
-{
-    struct _CacheEntry *entry;
-    unsigned char digest[MD5_DIGEST_LENGTH];
-    MD5_CTX md5ctx;
-    ssize_t bytes;
-    unsigned char data[1024];
-    char path[PATH_MAX];
-    size_t i;
-    gchar *out;
-    FILE *in;
-
-    entry = g_hash_table_lookup (cmng->h_entries, GUINT_TO_POINTER (ino));
-    if (!entry)
-        return FALSE;
-
-    if (range_count (entry->avail_range) != 1) {
-        LOG_debug (CMNG_LOG, INO_H"Entry contains more than 1 range, can't take MD5 sum of such object !", INO_T (ino));
-        return FALSE;
-    }
-
-    cache_mng_file_name (cmng, path, sizeof (path), ino);
-    in = fopen (path, "rb");
-    if (in == NULL) {
-        LOG_debug (CMNG_LOG, INO_H"Can't open file for reading: %s", INO_T (ino), path);
-        return FALSE;
-    }
-
-    MD5_Init (&md5ctx);
-    while ((bytes = fread (data, 1, 1024, in)) != 0)
-        MD5_Update (&md5ctx, data, bytes);
-    MD5_Final (digest, &md5ctx);
-    fclose (in);
-
-    out = g_malloc (33);
-    for (i = 0; i < 16; ++i)
-        sprintf (&out[i*2], "%02x", (unsigned int)digest[i]);
-
-    *md5str = out;
-
-    return TRUE;
-}
-
 // return version ID of cached file
 // return NULL if version ID is not set
 const gchar *cache_mng_get_version_id (CacheMng *cmng, fuse_ino_t ino)

--- a/src/conf.c
+++ b/src/conf.c
@@ -199,6 +199,7 @@ static void text_handler (G_GNUC_UNUSED GMarkupParseContext *context, const gcha
         }
     } else if (conf_node->type == CT_LIST) {
         l = NULL;
+        saved = NULL; // workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71701
         // split string and remove whitespaces
         for (tok = strtok_r (tmp_text, ",", &saved); tok; tok = strtok_r (NULL, ",", &saved)) {
             tok_striped = g_strstrip (tok);

--- a/src/dir_tree.c
+++ b/src/dir_tree.c
@@ -440,7 +440,7 @@ void dir_tree_fill_on_dir_buf_cb (gpointer callback_data, gboolean success)
     }
 
     LOG_debug (DIR_TREE_LOG, "[ino: %"INO_FMT" req: %p] Dir fill callback: %s",
-        INO_T (dir_fill_data->ino), dir_fill_data->req, success ? "SUCCESS" : "FAILED");
+        INO_T (dir_fill_data->ino), (void *)dir_fill_data->req, success ? "SUCCESS" : "FAILED");
 
     en->dir_cache_updating = FALSE;
     // directory is updated
@@ -1307,7 +1307,7 @@ void dir_tree_file_create (DirTree *dtree, fuse_ino_t parent_ino, const char *na
     fop = fileio_create (dtree->app, en->fullpath, en->ino, TRUE);
     fi->fh = (uint64_t) fop;
 
-    LOG_debug (DIR_TREE_LOG, INO_FOP_H"New Entry created: %s, directory ino: %"INO_FMT, INO_T (en->ino), fop, name, INO parent_ino);
+    LOG_debug (DIR_TREE_LOG, INO_FOP_H"New Entry created: %s, directory ino: %"INO_FMT, INO_T (en->ino), (void *)fop, name, INO parent_ino);
 
     file_create_cb (req, TRUE, en->ino, en->mode, en->size, fi);
 }
@@ -1334,7 +1334,7 @@ void dir_tree_file_open (DirTree *dtree, fuse_ino_t ino, struct fuse_file_info *
     fop = fileio_create (dtree->app, en->fullpath, en->ino, FALSE);
     fi->fh = (uint64_t) fop;
 
-    LOG_debug (DIR_TREE_LOG, INO_FOP_H"dir_tree_open", INO_T (en->ino), fop);
+    LOG_debug (DIR_TREE_LOG, INO_FOP_H"dir_tree_open", INO_T (en->ino), (void *)fop);
 
     file_open_cb (req, TRUE, fi);
 }
@@ -1359,7 +1359,7 @@ void dir_tree_file_release (DirTree *dtree, fuse_ino_t ino, G_GNUC_UNUSED struct
 
     fop = (FileIO *)fi->fh;
 
-    LOG_debug (DIR_TREE_LOG, INO_FOP_H"dir_tree_file_release", INO_T (ino), fop);
+    LOG_debug (DIR_TREE_LOG, INO_FOP_H"dir_tree_file_release", INO_T (ino), (void *)fop);
 
     fileio_release (fop);
 }
@@ -1378,10 +1378,10 @@ static void dir_tree_on_buffer_read_cb (gpointer ctx, gboolean success, char *bu
 {
     FileReadOpData *op_data = (FileReadOpData *)ctx;
 
-    LOG_debug (DIR_TREE_LOG, INO_FROP_H"file READ_cb !", INO_T (op_data->ino), op_data);
+    LOG_debug (DIR_TREE_LOG, INO_FROP_H"file READ_cb !", INO_T (op_data->ino), (void *)op_data);
 
     if (!success) {
-        LOG_err (DIR_TREE_LOG, INO_FROP_H"Failed to read file !", INO_T (op_data->ino), op_data);
+        LOG_err (DIR_TREE_LOG, INO_FROP_H"Failed to read file !", INO_T (op_data->ino), (void *)op_data);
         op_data->file_read_cb (op_data->req, FALSE, NULL, 0);
         g_free (op_data);
         return;
@@ -1413,7 +1413,7 @@ void dir_tree_file_read (DirTree *dtree, fuse_ino_t ino,
 
     fop = (FileIO *)fi->fh;
 
-    LOG_debug (DIR_TREE_LOG, INO_FOP_H"Read inode, size: %zu, off: %"OFF_FMT, INO_T (ino), fop, size, off);
+    LOG_debug (DIR_TREE_LOG, INO_FOP_H"Read inode, size: %zu, off: %"OFF_FMT, INO_T (ino), (void *)fop, size, off);
 
     op_data = g_new0 (FileReadOpData, 1);
     op_data->file_read_cb = file_read_cb;
@@ -1443,7 +1443,7 @@ static void dir_tree_on_buffer_written_cb (FileIO *fop, gpointer ctx, gboolean s
 
     op_data->file_write_cb (op_data->req, success, count);
 
-    LOG_debug (DIR_TREE_LOG, INO_FOP_H"Buffer written, count: %zu", INO_T (op_data->ino), fop, count);
+    LOG_debug (DIR_TREE_LOG, INO_FOP_H"Buffer written, count: %zu", INO_T (op_data->ino), (void *)fop, count);
 
     // we need to update entry size !
     if (success) {
@@ -1497,7 +1497,7 @@ void dir_tree_file_write (DirTree *dtree, fuse_ino_t ino,
     // set updated time for write op
     en->updated_time = time (NULL);
 
-    LOG_debug (DIR_TREE_LOG, INO_FOP_H"write inode, size: %zu, off: %"OFF_FMT, INO_T (ino), fop, size, off);
+    LOG_debug (DIR_TREE_LOG, INO_FOP_H"write inode, size: %zu, off: %"OFF_FMT, INO_T (ino), (void *)fop, size, off);
 
     op_data = g_new0 (FileWriteOpData, 1);
     op_data->dtree = dtree;
@@ -2006,7 +2006,7 @@ static void dir_tree_on_rename_copy_con_cb (gpointer client, gpointer ctx)
     else
         dst_path = g_strdup_printf ("/%s/%s", newparent_en->fullpath, rdata->newname);
 
-    LOG_debug (DIR_TREE_LOG, INO_CON_H"Rename: coping %s to %s", INO_T (en->ino), con, en->fullpath, dst_path);
+    LOG_debug (DIR_TREE_LOG, INO_CON_H"Rename: coping %s to %s", INO_T (en->ino), (void *)con, en->fullpath, dst_path);
 
     res = http_connection_make_request (con,
         dst_path, "PUT",

--- a/src/dir_tree.c
+++ b/src/dir_tree.c
@@ -85,6 +85,7 @@ static DirEntry *dir_tree_add_entry (DirTree *dtree, const gchar *basename, mode
     DirEntryType type, fuse_ino_t parent_ino, off_t size, time_t ctime);
 static void dir_tree_entry_modified (DirTree *dtree, DirEntry *en);
 static void dir_entry_destroy (gpointer data);
+static void dir_tree_entry_update_xattrs (DirEntry *en, struct evkeyvalq *headers);
 /*}}}*/
 
 /*{{{ create / destroy */
@@ -1533,7 +1534,7 @@ static void dir_tree_file_remove_on_con_data_cb (HttpConnection *con, gpointer c
         LOG_err (DIR_TREE_LOG, INO_H"Entry not found !", INO_T (data->ino));
         if (data->file_remove_cb)
             data->file_remove_cb (data->req, FALSE);
-		g_free (data);
+                g_free (data);
         return;
     }
 
@@ -2131,7 +2132,7 @@ static const gchar *dir_tree_getxattr_from_entry (DirEntry *en, XAttrType attr_t
     return out;
 }
 
-void dir_tree_entry_update_xattrs (DirEntry *en, struct evkeyvalq *headers)
+static void dir_tree_entry_update_xattrs (DirEntry *en, struct evkeyvalq *headers)
 {
     const gchar *header = NULL;
 

--- a/src/file_io_ops.c
+++ b/src/file_io_ops.c
@@ -109,13 +109,13 @@ static void fileio_release_on_update_header_cb (HttpConnection *con, void *ctx, 
     http_connection_release (con);
 
     if (!success) {
-        LOG_err (FIO_LOG, INO_CON_H"Failed to update headers on the server !", INO_T (fop->ino), con);
+        LOG_err (FIO_LOG, INO_CON_H"Failed to update headers on the server !", INO_T (fop->ino), (void *)con);
         fileio_destroy (fop);
         return;
     }
 
     // done
-    LOG_debug (FIO_LOG, INO_CON_H"Headers are updated !", INO_T (fop->ino), con);
+    LOG_debug (FIO_LOG, INO_CON_H"Headers are updated !", INO_T (fop->ino), (void *)con);
 
     fileio_destroy (fop);
 }
@@ -132,7 +132,7 @@ static void fileio_release_on_update_headers_con_cb (gpointer client, gpointer c
     gchar *md5str;
     size_t i;
 
-    LOG_debug (FIO_LOG, INO_CON_H"Updating object's headers..", INO_T (fop->ino), con);
+    LOG_debug (FIO_LOG, INO_CON_H"Updating object's headers..", INO_T (fop->ino), (void *)con);
 
     http_connection_acquire (con);
 
@@ -161,7 +161,7 @@ static void fileio_release_on_update_headers_con_cb (gpointer client, gpointer c
     g_free (path);
 
     if (!res) {
-        LOG_err (FIO_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (fop->ino), con);
+        LOG_err (FIO_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (fop->ino), (void *)con);
         http_connection_release (con);
         fileio_destroy (fop);
         return;
@@ -197,7 +197,7 @@ static void fileio_release_on_complete_cb (HttpConnection *con, void *ctx, gbool
     http_connection_release (con);
 
     if (!success) {
-        LOG_err (FIO_LOG, INO_CON_H"Failed to send Multipart data to the server !", INO_T (fop->ino), con);
+        LOG_err (FIO_LOG, INO_CON_H"Failed to send Multipart data to the server !", INO_T (fop->ino), (void *)con);
         fileio_destroy (fop);
         return;
     }
@@ -209,7 +209,7 @@ static void fileio_release_on_complete_cb (HttpConnection *con, void *ctx, gbool
     }
 
     // done
-    LOG_debug (FIO_LOG, INO_CON_H"Multipart Upload is done !", INO_T (fop->ino), con);
+    LOG_debug (FIO_LOG, INO_CON_H"Multipart Upload is done !", INO_T (fop->ino), (void *)con);
 
     // fileio_destroy (fop);
     fileio_release_update_headers (fop);
@@ -235,7 +235,7 @@ static void fileio_release_on_complete_con_cb (gpointer client, gpointer ctx)
     }
     evbuffer_add_printf (xml_buf, "%s", "</CompleteMultipartUpload>");
 
-    LOG_debug (FIO_LOG, INO_CON_H"Sending Multipart Final part..", INO_T (fop->ino), con);
+    LOG_debug (FIO_LOG, INO_CON_H"Sending Multipart Final part..", INO_T (fop->ino), (void *)con);
 
     http_connection_acquire (con);
 
@@ -250,7 +250,7 @@ static void fileio_release_on_complete_con_cb (gpointer client, gpointer ctx)
     evbuffer_free (xml_buf);
 
     if (!res) {
-        LOG_err (FIO_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (fop->ino), con);
+        LOG_err (FIO_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (fop->ino), (void *)con);
         http_connection_release (con);
         fileio_destroy (fop);
         return;
@@ -286,7 +286,7 @@ static void fileio_release_on_part_sent_cb (HttpConnection *con, void *ctx, gboo
     http_connection_release (con);
 
     if (!success) {
-        LOG_err (FIO_LOG, INO_CON_H"Failed to send bufer to server !", INO_T (fop->ino), con);
+        LOG_err (FIO_LOG, INO_CON_H"Failed to send bufer to server !", INO_T (fop->ino), (void *)con);
         fileio_destroy (fop);
         return;
     }
@@ -318,7 +318,7 @@ static void fileio_release_on_part_con_cb (gpointer client, gpointer ctx)
     size_t buf_len;
     const gchar *buf;
 
-    LOG_debug (FIO_LOG, INO_CON_H"Releasing fop. Size: %zu", INO_T (fop->ino), con, evbuffer_get_length (fop->write_buf));
+    LOG_debug (FIO_LOG, INO_CON_H"Releasing fop. Size: %zu", INO_T (fop->ino), (void *)con, evbuffer_get_length (fop->write_buf));
 
     // add part information to the list
     part = g_new0 (FileIOPart, 1);
@@ -338,7 +338,7 @@ static void fileio_release_on_part_con_cb (gpointer client, gpointer ctx)
     if (fop->multipart_initiated) {
 
         if (!fop->uploadid) {
-            LOG_err (FIO_LOG, INO_CON_H"UploadID is not set, aborting operation !", INO_T (fop->ino), con);
+            LOG_err (FIO_LOG, INO_CON_H"UploadID is not set, aborting operation !", INO_T (fop->ino), (void *)con);
             fileio_destroy (fop);
             return;
         }
@@ -392,7 +392,7 @@ static void fileio_release_on_part_con_cb (gpointer client, gpointer ctx)
     g_free (path);
 
     if (!res) {
-        LOG_err (FIO_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (fop->ino), con);
+        LOG_err (FIO_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (fop->ino), (void *)con);
         http_connection_release (con);
         fileio_destroy (fop);
         return;
@@ -448,7 +448,7 @@ static void fileio_write_on_send_cb (HttpConnection *con, void *ctx, gboolean su
     http_connection_release (con);
 
     if (!success) {
-        LOG_err (FIO_LOG, INO_CON_H"Failed to send bufer to server !", INO_T (wdata->ino), con);
+        LOG_err (FIO_LOG, INO_CON_H"Failed to send bufer to server !", INO_T (wdata->ino), (void *)con);
         wdata->on_buffer_written_cb (wdata->fop, wdata->ctx, FALSE, 0);
         g_free (wdata);
         return;
@@ -513,7 +513,7 @@ static void fileio_write_on_send_con_cb (gpointer client, gpointer ctx)
     g_free (path);
 
     if (!res) {
-        LOG_err (FIO_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (wdata->ino), con);
+        LOG_err (FIO_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (wdata->ino), (void *)con);
         http_connection_release (con);
         wdata->on_buffer_written_cb (wdata->fop, wdata->ctx, FALSE, 0);
         g_free (wdata);
@@ -595,7 +595,7 @@ static void fileio_write_on_multipart_init_cb (HttpConnection *con, void *ctx, g
     wdata->fop->multipart_initiated = TRUE;
 
     if (!success || !buf_len) {
-        LOG_err (FIO_LOG, INO_CON_H"Failed to get multipart init data from the server !", INO_T (wdata->ino), con);
+        LOG_err (FIO_LOG, INO_CON_H"Failed to get multipart init data from the server !", INO_T (wdata->ino), (void *)con);
         wdata->on_buffer_written_cb (wdata->fop, wdata->ctx, FALSE, 0);
         g_free (wdata);
         return;
@@ -603,7 +603,7 @@ static void fileio_write_on_multipart_init_cb (HttpConnection *con, void *ctx, g
 
     uploadid = get_uploadid (buf, buf_len);
     if (!uploadid) {
-        LOG_err (FIO_LOG, INO_CON_H"Failed to parse multipart init data!", INO_T (wdata->ino), con);
+        LOG_err (FIO_LOG, INO_CON_H"Failed to parse multipart init data!", INO_T (wdata->ino), (void *)con);
         wdata->on_buffer_written_cb (wdata->fop, wdata->ctx, FALSE, 0);
         g_free (wdata);
         return;
@@ -639,7 +639,7 @@ static void fileio_write_on_multipart_init_con_cb (gpointer client, gpointer ctx
     g_free (path);
 
     if (!res) {
-        LOG_err (FIO_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (wdata->ino), con);
+        LOG_err (FIO_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (wdata->ino), (void *)con);
         http_connection_release (con);
         wdata->on_buffer_written_cb (wdata->fop, wdata->ctx, FALSE, 0);
         g_free (wdata);
@@ -737,7 +737,7 @@ static void fileio_read_on_get_cb (HttpConnection *con, void *ctx, gboolean succ
     http_connection_release (con);
 
     if (!success) {
-        LOG_err (FIO_LOG, INO_CON_H"Failed to get file from server !", INO_T (rdata->ino), con);
+        LOG_err (FIO_LOG, INO_CON_H"Failed to get file from server !", INO_T (rdata->ino), (void *)con);
         rdata->on_buffer_read_cb (rdata->ctx, FALSE, NULL, 0);
         g_free (rdata);
         return;
@@ -797,7 +797,7 @@ static void fileio_read_on_con_cb (gpointer client, gpointer ctx)
     );
 
     if (!res) {
-        LOG_err (FIO_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (rdata->ino), con);
+        LOG_err (FIO_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (rdata->ino), (void *)con);
         http_connection_release (con);
         rdata->on_buffer_read_cb (rdata->ctx, FALSE, NULL, 0);
         g_free (rdata);
@@ -874,7 +874,7 @@ static void fileio_read_on_head_cb (HttpConnection *con, void *ctx, gboolean suc
     http_connection_release (con);
 
     if (!success) {
-        LOG_err (FIO_LOG, INO_CON_H"Failed to get HEAD from server !", INO_T (rdata->ino), con);
+        LOG_err (FIO_LOG, INO_CON_H"Failed to get HEAD from server !", INO_T (rdata->ino), (void *)con);
         rdata->on_buffer_read_cb (rdata->ctx, FALSE, NULL, 0);
         g_free (rdata);
         return;
@@ -895,7 +895,7 @@ static void fileio_read_on_head_cb (HttpConnection *con, void *ctx, gboolean suc
 
         size = strtoll ((char *)content_len_header, NULL, 10);
         if (size < 0) {
-            LOG_err (FIO_LOG, INO_CON_H"Header contains incorrect file size!", INO_T (rdata->ino), con);
+            LOG_err (FIO_LOG, INO_CON_H"Header contains incorrect file size!", INO_T (rdata->ino), (void *)con);
             size = 0;
         }
 
@@ -980,7 +980,7 @@ static void fileio_read_on_head_con_cb (gpointer client, gpointer ctx)
     );
 
     if (!res) {
-        LOG_err (FIO_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (rdata->ino), con);
+        LOG_err (FIO_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (rdata->ino), (void *)con);
         http_connection_release (con);
         rdata->on_buffer_read_cb (rdata->ctx, FALSE, NULL, 0);
         g_free (rdata);
@@ -1060,7 +1060,7 @@ static void fileio_simple_upload_on_con_cb (gpointer client, gpointer ctx)
     char time_str[50];
     gboolean res;
 
-    LOG_debug (FIO_LOG, CON_H"Uploading data. Size: %zu", con, evbuffer_get_length (fsim->write_buf));
+    LOG_debug (FIO_LOG, CON_H"Uploading data. Size: %zu", (void *)con, evbuffer_get_length (fsim->write_buf));
 
     http_connection_acquire (con);
 
@@ -1081,7 +1081,7 @@ static void fileio_simple_upload_on_con_cb (gpointer client, gpointer ctx)
     );
 
     if (!res) {
-        LOG_err (FIO_LOG, CON_H"Failed to create HTTP request !", con);
+        LOG_err (FIO_LOG, CON_H"Failed to create HTTP request !", (void *)con);
         http_connection_release (con);
         fsim->on_upload_cb (fsim->ctx, FALSE);
         fileio_simple_upload_destroy (fsim);
@@ -1142,7 +1142,7 @@ static void fileio_simple_download_on_con_cb (gpointer client, gpointer ctx)
     FileIOSimpleDownload *fsim = (FileIOSimpleDownload *) ctx;
     gboolean res;
 
-    LOG_debug (FIO_LOG, CON_H"Downloading data.", con);
+    LOG_debug (FIO_LOG, CON_H"Downloading data.", (void *)con);
 
     http_connection_acquire (con);
 
@@ -1155,7 +1155,7 @@ static void fileio_simple_download_on_con_cb (gpointer client, gpointer ctx)
     );
 
     if (!res) {
-        LOG_err (FIO_LOG, CON_H"Failed to create HTTP request !", con);
+        LOG_err (FIO_LOG, CON_H"Failed to create HTTP request !", (void *)con);
         http_connection_release (con);
         fsim->on_download_cb (fsim->ctx, FALSE, NULL, 0);
         fileio_simple_download_destroy (fsim);

--- a/src/file_io_ops.c
+++ b/src/file_io_ops.c
@@ -286,7 +286,7 @@ static void fileio_release_on_part_sent_cb (HttpConnection *con, void *ctx, gboo
     http_connection_release (con);
 
     if (!success) {
-        LOG_err (FIO_LOG, INO_CON_H"Failed to send bufer to server !", INO_T (fop->ino), (void *)con);
+        LOG_err (FIO_LOG, INO_CON_H"Failed to send buffer to server !", INO_T (fop->ino), (void *)con);
         fileio_destroy (fop);
         return;
     }
@@ -448,7 +448,7 @@ static void fileio_write_on_send_cb (HttpConnection *con, void *ctx, gboolean su
     http_connection_release (con);
 
     if (!success) {
-        LOG_err (FIO_LOG, INO_CON_H"Failed to send bufer to server !", INO_T (wdata->ino), (void *)con);
+        LOG_err (FIO_LOG, INO_CON_H"Failed to send buffer to server !", INO_T (wdata->ino), (void *)con);
         wdata->on_buffer_written_cb (wdata->fop, wdata->ctx, FALSE, 0);
         g_free (wdata);
         return;

--- a/src/file_io_ops.c
+++ b/src/file_io_ops.c
@@ -885,12 +885,10 @@ static void fileio_read_on_head_cb (HttpConnection *con, void *ctx, gboolean suc
     dtree = application_get_dir_tree (rdata->fop->app);
     dir_tree_set_entry_exist (dtree, rdata->ino);
 
-    // consistency checking:
-
-    // 1. check local and remote file sizes
     content_len_header = http_find_header (headers, "Content-Length");
+
+    // Set file size from header Content-Length
     if (content_len_header) {
-        guint64 local_size = 0;
         gint64 size = 0;
 
         size = strtoll ((char *)content_len_header, NULL, 10);
@@ -901,6 +899,13 @@ static void fileio_read_on_head_cb (HttpConnection *con, void *ctx, gboolean suc
 
         rdata->fop->file_size = size;
         LOG_debug (FIO_LOG, INO_H"Remote file size: %"G_GUINT64_FORMAT, INO_T (rdata->ino), rdata->fop->file_size);
+    }
+
+    // consistency checking:
+
+    // 1. check local and remote file sizes
+    if (content_len_header) {
+        guint64 local_size;
 
         local_size = cache_mng_get_file_length (application_get_cache_mng (rdata->fop->app), rdata->ino);
         if (local_size != rdata->fop->file_size) {

--- a/src/http_connection_dir_list.c
+++ b/src/http_connection_dir_list.c
@@ -298,19 +298,19 @@ static void http_connection_on_directory_listing_data (HttpConnection *con, void
     gboolean res;
 
     if (!buf_len || !buf) {
-        LOG_err (CON_DIR_LOG, INO_CON_H"Directory buffer is empty !", INO_T (dir_req->ino), con);
+        LOG_err (CON_DIR_LOG, INO_CON_H"Directory buffer is empty !", INO_T (dir_req->ino), (void *)con);
         directory_listing_done (con, dir_req, FALSE);
         return;
     }
 
     if (!success) {
-        LOG_err (CON_DIR_LOG, INO_CON_H"Error getting directory list !", INO_T (dir_req->ino), con);
+        LOG_err (CON_DIR_LOG, INO_CON_H"Error getting directory list !", INO_T (dir_req->ino), (void *)con);
         directory_listing_done (con, dir_req, FALSE);
         return;
     }
 
     if (!parse_dir_xml (dir_req, buf, buf_len)) {
-        LOG_err (CON_DIR_LOG, INO_CON_H"Error parsing directory XML !", INO_T (dir_req->ino), con);
+        LOG_err (CON_DIR_LOG, INO_CON_H"Error parsing directory XML !", INO_T (dir_req->ino), (void *)con);
         directory_listing_done (con, dir_req, FALSE);
         return;
     }
@@ -320,7 +320,7 @@ static void http_connection_on_directory_listing_data (HttpConnection *con, void
 
     // check if we need to get more data
     if (!g_strstr_len (buf, buf_len, "<IsTruncated>true</IsTruncated>") && !next_marker) {
-        LOG_debug (CON_DIR_LOG, INO_CON_H"Directory listing done !", INO_T (dir_req->ino), con);
+        LOG_debug (CON_DIR_LOG, INO_CON_H"Directory listing done !", INO_T (dir_req->ino), (void *)con);
         directory_listing_done (con, dir_req, TRUE);
         return;
     }
@@ -339,7 +339,7 @@ static void http_connection_on_directory_listing_data (HttpConnection *con, void
     g_free (req_path);
 
     if (!res) {
-        LOG_err (CON_DIR_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (dir_req->ino), con);
+        LOG_err (CON_DIR_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (dir_req->ino), (void *)con);
         directory_listing_done (con, dir_req, FALSE);
         return;
     }
@@ -353,7 +353,7 @@ void http_connection_get_directory_listing (HttpConnection *con, const gchar *di
     gchar *req_path;
     gboolean res;
 
-    LOG_debug (CON_DIR_LOG, INO_CON_H"Getting directory listing for: >>%s<<", INO_T (con), con, dir_path);
+    LOG_debug (CON_DIR_LOG, INO_CON_H"Getting directory listing for: >>%s<<", INO_T (con), (void *)con, dir_path);
 
     dir_req = g_new0 (DirListRequest, 1);
     dir_req->con = con;
@@ -386,7 +386,7 @@ void http_connection_get_directory_listing (HttpConnection *con, const gchar *di
     g_free (req_path);
 
     if (!res) {
-        LOG_err (CON_DIR_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (dir_req->ino), con);
+        LOG_err (CON_DIR_LOG, INO_CON_H"Failed to create HTTP request !", INO_T (dir_req->ino), (void *)con);
         directory_listing_done (con, dir_req, FALSE);
         return;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -289,7 +289,7 @@ static void sigusr1_cb (G_GNUC_UNUSED evutil_socket_t sig, G_GNUC_UNUSED short e
         LOG_err (APP_LOG, "Failed to parse configuration file: %s", _app->conf_path);
         conf_destroy(conf_new);
     } else {
-        const gchar *copy_entries[] = {"s3.host", "s3.port", "s3.versioning", "s3.access_key_id", "s3.secret_access_key", "s3.bucket_name", NULL};
+        const gchar *copy_entries[] = {"s3.host", "s3.port", "s3.access_key_id", "s3.secret_access_key", "s3.bucket_name", NULL};
         int i;
 
         _app->conf = conf_new;
@@ -483,39 +483,6 @@ static gint application_finish_initialization_and_run (Application *app)
 }
 /*}}}*/
 
-/*{{{ application_on_bucket_versioning_cb */
-//  replies on bucket versioning information
-static void application_on_bucket_versioning_cb (gpointer ctx, gboolean success,
-    const gchar *buf, size_t buf_len)
-{
-    Application *app = (Application *)ctx;
-    gchar *tmp;
-
-    if (!success) {
-        LOG_err (APP_LOG, "Failed to get bucket versioning!");
-        application_exit (app);
-        return;
-    }
-
-    if (buf_len > 1) {
-        tmp = (gchar *)buf;
-        tmp[buf_len - 1] = '\0';
-
-        if (strstr (buf, "<Status>Enabled</Status>")) {
-            LOG_debug (APP_LOG, "Bucket has versioning enabled !");
-            conf_set_boolean (app->conf, "s3.versioning", TRUE);
-        } else {
-            LOG_debug (APP_LOG, "Bucket has versioning disabled !");
-            conf_set_boolean (app->conf, "s3.versioning", FALSE);
-        }
-    } else {
-        conf_set_boolean (app->conf, "s3.versioning", FALSE);
-    }
-
-    application_finish_initialization_and_run (app);
-}
-/*}}}*/
-
 /*{{{ application_on_bucket_acl_cb */
 //  replies on bucket ACL
 static void application_on_bucket_acl_cb (gpointer ctx, gboolean success,
@@ -531,7 +498,7 @@ static void application_on_bucket_acl_cb (gpointer ctx, gboolean success,
 
     // XXX: check ACL permissions
 
-    bucket_client_get (app->service_con, "/?versioning", application_on_bucket_versioning_cb, app);
+    application_finish_initialization_and_run (app);
 }
 /*}}}*/
 

--- a/src/rfuse.c
+++ b/src/rfuse.c
@@ -617,7 +617,7 @@ static void rfuse_open (fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *f
 {
     RFuse *rfuse = fuse_req_userdata (req);
 
-    LOG_debug (FUSE_LOG, INO_FI_H"open inode, flags: %d", INO_T (ino), fi, fi->flags);
+    LOG_debug (FUSE_LOG, INO_FI_H"open inode, flags: %d", INO_T (ino), (void *)fi, fi->flags);
 
     dir_tree_file_open (rfuse->dir_tree, ino, fi, rfuse_open_cb, req);
 }
@@ -630,7 +630,7 @@ void rfuse_create_cb (fuse_req_t req, gboolean success, fuse_ino_t ino, int mode
     struct fuse_entry_param e;
     RFuse *rfuse = fuse_req_userdata (req);
 
-    LOG_debug (FUSE_LOG, INO_FI_H"add_file_cb  success: %s", INO_T (ino), fi, success?"YES":"NO");
+    LOG_debug (FUSE_LOG, INO_FI_H"add_file_cb  success: %s", INO_T (ino), (void *)fi, success?"YES":"NO");
     if (!success) {
         fuse_reply_err (req, ENOENT);
         return;
@@ -673,7 +673,7 @@ static void rfuse_release (fuse_req_t req, fuse_ino_t ino, struct fuse_file_info
 {
     RFuse *rfuse = fuse_req_userdata (req);
 
-    LOG_debug (FUSE_LOG, INO_FI_H"release  inode, flags: %d", INO_T (ino), fi, fi->flags);
+    LOG_debug (FUSE_LOG, INO_FI_H"release  inode, flags: %d", INO_T (ino), (void *)fi, fi->flags);
 
     dir_tree_file_release (rfuse->dir_tree, ino, fi);
 
@@ -687,7 +687,7 @@ static void rfuse_release (fuse_req_t req, fuse_ino_t ino, struct fuse_file_info
 static void rfuse_read_cb (fuse_req_t req, gboolean success, const char *buf, size_t buf_size)
 {
 
-    LOG_debug (FUSE_LOG, "[req: %p] <<<<< read_cb  success: %s IN buf: %zu", req, success?"YES":"NO", buf_size);
+    LOG_debug (FUSE_LOG, "[req: %p] <<<<< read_cb  success: %s IN buf: %zu", (void *)req, success?"YES":"NO", buf_size);
 
     if (!success) {
         fuse_reply_err (req, ENOENT);
@@ -703,7 +703,7 @@ static void rfuse_read (fuse_req_t req, fuse_ino_t ino, size_t size, off_t off, 
 {
     RFuse *rfuse = fuse_req_userdata (req);
 
-    LOG_debug (FUSE_LOG, INO_FI_H">>>> read  inode, size: %zu, off: %"OFF_FMT, INO_T (ino), fi, size, off);
+    LOG_debug (FUSE_LOG, INO_FI_H">>>> read  inode, size: %zu, off: %"OFF_FMT, INO_T (ino), (void *)fi, size, off);
 
     rfuse->read_ops++;
     dir_tree_file_read (rfuse->dir_tree, ino, size, off, rfuse_read_cb, req, fi);
@@ -714,7 +714,7 @@ static void rfuse_read (fuse_req_t req, fuse_ino_t ino, size_t size, off_t off, 
 // write callback
 static void rfuse_write_cb (fuse_req_t req, gboolean success, size_t count)
 {
-    LOG_debug (FUSE_LOG, "[req: %p] write_cb  success: %s", req, success?"YES":"NO");
+    LOG_debug (FUSE_LOG, "[req: %p] write_cb  success: %s", (void *)req, success?"YES":"NO");
 
     if (!success) {
         fuse_reply_err (req, ENOENT);
@@ -729,7 +729,7 @@ static void rfuse_write (fuse_req_t req, fuse_ino_t ino, const char *buf, size_t
 {
     RFuse *rfuse = fuse_req_userdata (req);
 
-    LOG_debug (FUSE_LOG, INO_FI_H"write inode, size: %zu, off: %"OFF_FMT, INO_T (ino), fi, size, off);
+    LOG_debug (FUSE_LOG, INO_FI_H"write inode, size: %zu, off: %"OFF_FMT, INO_T (ino), (void *)fi, size, off);
 
     rfuse->write_ops++;
     dir_tree_file_write (rfuse->dir_tree, ino, buf, size, off, rfuse_write_cb, req, fi);
@@ -768,7 +768,7 @@ static void rfuse_forget (fuse_req_t req, fuse_ino_t ino, unsigned long nlookup)
 
 static void rfuse_unlink_cb (fuse_req_t req, gboolean success)
 {
-    LOG_debug (FUSE_LOG, "[%p] success: %s", req, success ? "TRUE" : "FALSE");
+    LOG_debug (FUSE_LOG, "[%p] success: %s", (void *)req, success ? "TRUE" : "FALSE");
 
     if (success)
         fuse_reply_err (req, 0);
@@ -783,7 +783,7 @@ static void rfuse_unlink (fuse_req_t req, fuse_ino_t parent, const char *name)
 {
     RFuse *rfuse = fuse_req_userdata (req);
 
-    LOG_debug (FUSE_LOG, "[%p] unlink  parent_ino: %"INO_FMT", name: %s", req, INO parent, name);
+    LOG_debug (FUSE_LOG, "[%p] unlink  parent_ino: %"INO_FMT", name: %s", (void *)req, INO parent, name);
 
     dir_tree_file_unlink (rfuse->dir_tree, parent, name, rfuse_unlink_cb, req);
 }
@@ -843,7 +843,7 @@ static void rfuse_rmdir (fuse_req_t req, fuse_ino_t parent_ino, const char *name
 {
     RFuse *rfuse = fuse_req_userdata (req);
 
-    LOG_debug (FUSE_LOG, "[%p] rmdir  parent_ino: %"INO_FMT", name: %s", rfuse, INO parent_ino, name);
+    LOG_debug (FUSE_LOG, "[%p] rmdir  parent_ino: %"INO_FMT", name: %s", (void *)rfuse, INO parent_ino, name);
 
     // notify dir tree
     if (dir_tree_dir_remove (rfuse->dir_tree, parent_ino, name, req))
@@ -997,7 +997,7 @@ static void rfuse_symlink (fuse_req_t req, const char *link, fuse_ino_t parent_i
 {
     RFuse *rfuse = fuse_req_userdata (req);
 
-    LOG_debug (FUSE_LOG, "[%p] symlink  parent_ino: %"INO_FMT", name: %s link: %s", rfuse, INO parent_ino, name, link);
+    LOG_debug (FUSE_LOG, "[%p] symlink  parent_ino: %"INO_FMT", name: %s link: %s", (void *)rfuse, INO parent_ino, name, link);
 
     dir_tree_create_symlink (rfuse->dir_tree, parent_ino, name, link, rfuse_symlik_cb, req);
 }
@@ -1020,7 +1020,7 @@ static void rfuse_readlink (fuse_req_t req, fuse_ino_t ino)
 {
     RFuse *rfuse = fuse_req_userdata (req);
 
-    LOG_debug (FUSE_LOG, "[%p] readlink ino: %"INO_FMT, rfuse, INO ino);
+    LOG_debug (FUSE_LOG, "[%p] readlink ino: %"INO_FMT, (void *)rfuse, INO ino);
 
     dir_tree_readlink (rfuse->dir_tree, ino, rfuse_readlink_cb, req);
 }
@@ -1030,7 +1030,7 @@ static void rfuse_readlink (fuse_req_t req, fuse_ino_t ino)
 // XXX: currently just a placeholder, does nothing
 static void rfuse_flush_cb (fuse_req_t req, gboolean success)
 {
-    LOG_debug (FUSE_LOG, "[req: %p] flush_cb  success: %s", req, success?"YES":"NO");
+    LOG_debug (FUSE_LOG, "[req: %p] flush_cb  success: %s", (void *)req, success?"YES":"NO");
 
     if (!success) {
         fuse_reply_err (req, ENOENT);
@@ -1040,11 +1040,11 @@ static void rfuse_flush_cb (fuse_req_t req, gboolean success)
     fuse_reply_err (req, 0);
 }
 
-static void rfuse_flush (fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
+static void rfuse_flush (fuse_req_t req, fuse_ino_t ino, G_GNUC_UNUSED struct fuse_file_info *fi)
 {
     RFuse *rfuse = fuse_req_userdata (req);
 
-    LOG_debug (FUSE_LOG, "[%p][req: %p] flush ino: %"INO_FMT, rfuse, req, INO ino);
+    LOG_debug (FUSE_LOG, "[%p][req: %p] flush ino: %"INO_FMT, (void *)rfuse, (void *)req, INO ino);
 
     rfuse_flush_cb (req, TRUE);
 }

--- a/src/rfuse.c
+++ b/src/rfuse.c
@@ -902,7 +902,7 @@ static void rfuse_listxattr (fuse_req_t req, fuse_ino_t ino, size_t size)
 
 static void rfuse_getxattr_cb (fuse_req_t req, gboolean success, fuse_ino_t ino, const gchar *str, size_t size)
 {
-    LOG_debug (FUSE_LOG, INO_H"getattr_cb  success: %s  str: %s", INO_T (ino), success?"YES":"NO", str);
+    LOG_debug (FUSE_LOG, INO_H"getxattr_cb  success: %s  str: %s", INO_T (ino), success?"YES":"NO", str);
 
     if (!success || !str) {
         fuse_reply_err (req, ENOTSUP);

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from subprocess import Popen, PIPE
 from StringIO import StringIO


### PR DESCRIPTION
As I have written at more length in https://github.com/skoobe/riofs/issues/136, this set of patches, which replaces the methods of checking whether the cache is still valid with a single method using ETags, is now ready for consideration to pull into the main branch.

See in particular patch "3ee963e ETag fix #3: add ETag consistency checking" for the most interesting details of this change.

Thanks!