### PR TITLE
Build issues on macOS

### DIFF
--- a/riofs.rb
+++ b/riofs.rb
@@ -16,7 +16,7 @@ class Riofs < Formula
 
   def install
     system "./autogen.sh"
-    system "./configure --prefix=#{prefix}"
+    system %Q[./configure --prefix=#{prefix} CFLAGS="-D_XOPEN_SOURCE"]
     system "make install"
   end
 end


### PR DESCRIPTION
The PR is a one-line change, but there are really several apparent issues here. I'm only glancingly familiar with the internal details of autoconf and Homebrew, so I hesitate to suggest a specific fix. But let me see if I can describe the problems in sufficient detail that someone more familiar with these tools might know the proper update.

The top-level issue is that as of the current beta of macOS High Sierra (10.13.5, build 17F45c, with Xcode 9.3) --- and possibly for a while --- `/usr/include/ucontext.h` explicitly checks to see if the preprocessor symbol `_XOPEN_SOURCE` is defined, and if it is not, it aborts with the message "The deprecated ucontext routines require _XOPEN_SOURCE to be defined." `riofs` doesn't include this header directly, but it's being pulled in by something else. So currently, if you just use the recommended installation method of 

```
brew install https://raw.github.com/skoobe/riofs/master/riofs.rb
```
the compilation aborts midway through.

Defining this symbol lets the compilation proceed, and `riofs` seems to work fine. This PR adds it to the Homebrew control file, but perhaps there's somewhere else in the configuration that it could go so as to cover non-Homebrew builds.

`_XOPEN_SOURCE` is some kind of POSIX compatibility flag, and it's supposed to have a value, as described [here](https://stackoverflow.com/questions/5378778/what-does-d-xopen-source-do-mean). Unfortunately, values of 700L, 600L, and 500L all produce catastrophic compilation meltdowns because of stuff that goes on in `/usr/include/sys/cdefs.h`. Just defining it without a value seems to be sufficient to sneak by the `ucontext.h` police without causing problems.

I also found that if you try to build `riofs` outside of Homebrew, the build system aborts because it can't confirm that libcrypto is installed. In macOS, this library is part of the base system. Homebrew provides a synthetic `pkg-config` receipt for it (on my system, `/usr/local/Homebrew/Library/Homebrew/os/mac/pkgconfig/10.5/libcrypto.pc`) and is able to set up the environment so that `pkg-config` finds it.

However, when you run the build through `./configure` directly, you have to provide an explicit `PKG_CONFIG_DIR=/usr/local/Homebrew/Library/Homebrew/os/mac/pkgconfig/10.5` argument to fix this problem. Unfortunately, you can't include that same argument in the `riofs.rb` file since it seems to screw up other autoconfiguration that Homebrew is already doing. The build then finds `libcrypto` but not `glibc`.

Perhaps the right solution is just to take this PR as-is and to clarify that `riofs` must only be installed through Homebrew; manual compilation isn't supported.